### PR TITLE
Enable configuring test reporters via config

### DIFF
--- a/dev-resources/circleci_test/config.clj
+++ b/dev-resources/circleci_test/config.clj
@@ -1,2 +1,8 @@
+(require '[circleci.test.report :refer (clojure-test-reporter)])
+(require '[circleci.test.report.junit :as junit])
+
 {:selectors {:all (constantly true)
-             :default (complement :failing)}}
+             :default (complement :failing)}
+ :reporters [(clojure-test-reporter)
+             (junit/reporter (or (System/getenv "CIRCLE_TEST_REPORTS")
+                                 "."))]}

--- a/src/circleci/test.clj
+++ b/src/circleci/test.clj
@@ -23,7 +23,7 @@
 ;; dummy once-fixture.
 (def ^:dynamic *once-fixtures* {})
 
-(defn- read-config []
+(defn- read-config! []
   (if-let [r (io/resource "circleci_test/config.clj")]
     (load-reader (clojure.lang.LineNumberingPushbackReader. (io/reader r)))
     {}))
@@ -84,7 +84,7 @@
   This could be by invoking a deftest directly from a repl, editor integration
   etc."
   ([v]
-   (test-var (read-config) v))
+   (test-var (read-config!) v))
   ([config v]
    ;; Make sure calling any nested test fns invokes _our_ test-var, not
    ;; clojure.test's
@@ -113,35 +113,35 @@
   *initial-report-counters*.  Returns the final, dereferenced state of
   *report-counters*."
   ([ns] (test-ns ns (constantly true)))
-  ([ns selector]
-   (let [config (read-config)]
-     (binding [test/*report-counters* (ref test/*initial-report-counters*)
-               test/report report/report
-               report/*reporters* (:reporters config report/*reporters*)]
-       (let [ns-obj (the-ns ns)
-             once-fixture-fn (once-fixtures ns-obj)]
-         (once-fixture-fn
-          (fn []
-            (test/do-report {:type :begin-test-ns, :ns ns-obj})
-            ;; If the namespace has a test-ns-hook function, call that:
-            (if-let [v (find-var (symbol (str (ns-name ns-obj)) "test-ns-hook"))]
-              ((var-get v))
-              ;; Otherwise, just test every var in the namespace.
-              (test-all-vars config ns-obj selector))
-            (test/do-report {:type :end-test-ns, :ns ns-obj}))))
-       @test/*report-counters*))))
+  ([ns selector] (test-ns (read-config!) ns selector))
+  ([config ns selector]
+   (binding [test/*report-counters* (ref test/*initial-report-counters*)
+             test/report report/report
+             report/*reporters* (:reporters config report/*reporters*)]
+     (let [ns-obj (the-ns ns)
+           once-fixture-fn (once-fixtures ns-obj)]
+       (once-fixture-fn
+        (fn []
+          (test/do-report {:type :begin-test-ns, :ns ns-obj})
+          ;; If the namespace has a test-ns-hook function, call that:
+          (if-let [v (find-var (symbol (str (ns-name ns-obj)) "test-ns-hook"))]
+            ((var-get v))
+            ;; Otherwise, just test every var in the namespace.
+            (test-all-vars config ns-obj selector))
+          (test/do-report {:type :end-test-ns, :ns ns-obj}))))
+     @test/*report-counters*)))
 
 
 ;; Running tests; high-level fns
 
-(defn run-selected-tests
+(defn- run-selected-tests
   "Runs tests filtered by selector function in given namespace; prints results.
   Defaults to current namespace if none given.  Returns a map
   summarizing test results."
-  ([selector] (run-selected-tests selector *ns*))
-  ([selector & namespaces]
+  ([selector] (run-selected-tests (read-config!) selector *ns*))
+  ([config selector & namespaces]
    (let [summary (assoc (apply merge-with + (for [n namespaces]
-                                              (test-ns n selector)))
+                                              (test-ns config n selector)))
                         :type :summary)]
      (test/do-report summary)
      summary)))
@@ -162,15 +162,15 @@
   ([] (apply run-tests (all-ns)))
   ([re] (apply run-tests (filter #(re-matches re (name (ns-name %))) (all-ns)))))
 
-(defn- lookup-selector [selector-name]
-  (let [selectors (:selectors (read-config) {:default identity})]
+(defn- lookup-selector [config selector-name]
+  (let [selectors (:selectors config {:default identity})]
     (or (get selectors selector-name) selector-name)))
 
-(defn- read-args [raw-args]
+(defn- read-args [config raw-args]
   (let [args (map read-string raw-args)]
     (if (keyword? (first args)) ; the selector must be the first arg
-      (cons (lookup-selector (first args)) (rest args))
-      (cons (lookup-selector :default) args))))
+      (cons (lookup-selector config (first args)) (rest args))
+      (cons (lookup-selector config :default) args))))
 
 (defn- nses-in-directories [dirs]
   (for [dir dirs f (file-seq (io/file dir))
@@ -196,7 +196,8 @@
   [& raw-args]
   (when (empty? raw-args)
     (throw (ex-info "Must pass a list of namespaces to test" {})))
-  (let [[selector & nses] (read-args raw-args)
+  (let [config (read-config!)
+        [selector & nses] (read-args config raw-args)
         _ (apply require :reload nses)
-        summary (apply run-selected-tests selector nses)]
+        summary (apply run-selected-tests config selector nses)]
     (System/exit (+ (:error summary) (:fail summary)))))

--- a/src/circleci/test/report.clj
+++ b/src/circleci/test/report.clj
@@ -85,7 +85,11 @@
   []
   (->ClojureDotTestReporter))
 
-(def ^:dynamic *reporters* [(clojure-test-reporter)])
+(def ^:dynamic *reporters*
+  "The sequence of currently configured test reporters. Consumers of the
+  circleci.test library should not bind this var, set the :reporters key in
+  test runner config instead."
+  [(clojure-test-reporter)])
 
 ;; Test result reporting
 (defmulti

--- a/test/circleci/test_test.clj
+++ b/test/circleci/test_test.clj
@@ -123,7 +123,7 @@
 (defn test-ns-hook []
   (binding [original-report clojure.test/report
             report/report custom-report]
-    (#'t/test-all-vars (find-ns 'circleci.test-test) (constantly true))))
+    (#'t/test-all-vars {} (find-ns 'circleci.test-test) (constantly true))))
 
 (deftest clj-1588-symbols-in-are-isolated-from-test-clauses
   (binding [clojure.test/report original-report]


### PR DESCRIPTION
Fixes #4 

Use `load-reader` to load the whole config file, this allows config code to
import namespaces sensibly.
Note: namespaces could always be imported by invoking `require` in a `do` or
`let` form inside the config map definition so this shouldn't introduce any
additional risk.

`test-ns`/`test-var` make sure that config is only read once per test
namespace, this is important to retain the same test reporter objects for all
tests belonging to the test namespace.

Add sample config that instantiates test reporters

I still need to work out how to test this properly. I've confirmed it works by
updating another repo to use this circleci.test code and setting a config.clj.

I am still concerned about looking up a resource and loading the code within it
unconditionally, some additional checks to ensure it came from the current
project are necessary.