### PR TITLE
Only prn unknown `report` methods when DEBUG is set.

### DIFF
--- a/src/circleci/test/report.clj
+++ b/src/circleci/test/report.clj
@@ -33,10 +33,13 @@
   (begin-test-var [this m])
   (end-test-var [this m]))
 
+(def ^:dynamic *debug* (boolean (System/getenv "DEBUG")))
+
 (deftype ClojureDotTestReporter []
   TestReporter
   (default [this m]
-    (test/with-test-out (prn m)))
+    (when *debug*
+      (test/with-test-out (prn m))))
 
   (pass [this m]
     (test/with-test-out (test/inc-report-counter :pass)))


### PR DESCRIPTION
tl;dr: the default method for `report` is to just call `prn`, so when a lib like `clojure.test.check` adds a new `defmethod` to `clojure.test/report` which isn't normally printed, it results in a ton of spurious output when we rebind our `defmulti` to replace `clojure.test/report`.

The fix is to only output the unknown `report` calls when the `DEBUG` environment variable is set. In the future if we encounter other libs that add `defmethod`s, we can use this to figure out what's really going on and fix it, but it probably shouldn't spam stdout otherwise?

Fixes #20, but I don't know if it's the right answer for sure. It feels like it might be just more of a band-aid.