### PR TITLE
Port to data.xml v0.2.0-alpha5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
           key: v1-jars-
 
       - run: lein test
+      - run: lein with-profile +alpha-data-xml test
 
       - cache-save:
           key: v1-jars-{{ checksum "project.clj" }}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.xml "0.0.8"]]
+                 [org.clojure/data.xml "0.2.0-alpha5"]]
   :aliases {"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
             "tests" ["run" "-m" "circleci.test"]
             "retest" ["run" "-m" "circleci.test.retest"]})

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,9 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.xml "0.2.0-alpha5"]]
+                 [org.clojure/data.xml "0.0.8"]]
+  :profiles {:alpha-data-xml
+             {:dependencies [[org.clojure/data.xml "0.2.0-alpha5"]]}}
   :aliases {"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
             "tests" ["run" "-m" "circleci.test"]
             "retest" ["run" "-m" "circleci.test.retest"]})

--- a/src/circleci/test/report/junit.clj
+++ b/src/circleci/test/report/junit.clj
@@ -1,9 +1,11 @@
 (ns circleci.test.report.junit
   "Junit reporter for circleci.test"
   (:require [clojure.data.xml :as xml]
-            [clojure.data.xml.node :refer [element?]]
             [clojure.java.io :as io]
             [circleci.test.report :as report]))
+
+(defn- element? [el]
+  (and (map? el) (some? (:tag el))))
 
 (defn- stacktrace->string
   "given an exception, returns the result of printStackTrace as a string"

--- a/src/circleci/test/report/junit.clj
+++ b/src/circleci/test/report/junit.clj
@@ -1,9 +1,9 @@
 (ns circleci.test.report.junit
   "Junit reporter for circleci.test"
   (:require [clojure.data.xml :as xml]
+            [clojure.data.xml.node :refer [element?]]
             [clojure.java.io :as io]
-            [circleci.test.report :as report])
-  (:import clojure.data.xml.Element))
+            [circleci.test.report :as report]))
 
 (defn- stacktrace->string
   "given an exception, returns the result of printStackTrace as a string"
@@ -38,8 +38,8 @@
 
 (defn- suite-xml
   [m testcases]
-  {:pre [(class testcases) (every? #(instance? Element %) testcases)]}
-  (apply xml/element :testsuite {:name (-> m :ns (.name))
+  {:pre [(class testcases) (every? element? testcases)]}
+  (apply xml/element :testsuite {:name (-> m :ns ns-name str)
                                  :errors (count-errors testcases)
                                  :tests (count testcases)
                                  :failures (count-failures testcases)
@@ -48,7 +48,7 @@
 
 (defn- test-name
   [v]
-  (-> v meta :name))
+  (-> v meta :name str))
 
 (defn- testcase-xml
   "Generate a testcase XML element. Takes the map from a (clojure.test/do-report :end-test-var), and a seq of failure/error reports "

--- a/test/circleci/test/report/test_junit.clj
+++ b/test/circleci/test/report/test_junit.clj
@@ -1,20 +1,20 @@
 (ns circleci.test.report.test-junit
   (:require [clojure.test :refer (deftest testing is)]
+            [clojure.data.xml.node :refer [element?]]
             circleci.test
             circleci.test.report
             [circleci.test.report.junit :as junit])
-  (:import clojure.data.xml.Element
-           java.nio.file.Files
+  (:import java.nio.file.Files
            java.nio.file.attribute.FileAttribute))
 
 (deftest failure-works
-  (is (instance? Element (#'junit/failure-xml
-                          {:expected (= 3 (+ 1 1)),
-                           :message nil,
-                           :type :fail,
-                           :actual (not (= 3 2)),
-                           :file "test_junit.clj",
-                           :line 8}))))
+  (is (element? (#'junit/failure-xml
+                 {:expected (= 3 (+ 1 1)),
+                  :message nil,
+                  :type :fail,
+                  :actual (not (= 3 2)),
+                  :file "test_junit.clj",
+                  :line 8}))))
 
 (deftest testcase-works
   (let [ret (#'junit/testcase-xml {:type :end-test-var
@@ -27,23 +27,23 @@
                                     :actual (not (= 3 2)),
                                     :file "test_junit.clj",
                                     :line 8}))]
-    (is (instance? Element ret))
+    (is (element? ret))
     (testing "it has a time"
       (is (-> ret :attrs :time float?)))))
 
 (deftest testsuite-works
-  (is (instance? Element
-                 (#'junit/suite-xml {:ns (find-ns 'clojure.core)}
-                                    [(#'junit/testcase-xml {:type :end-test-var
-                                                            :name #'clojure.core/map
-                                                            :elapsed 0.03}
-                                                           [(#'junit/failure-xml
-                                                             {:expected (= 3 (+ 1 1)),
-                                                              :message nil,
-                                                              :type :fail,
-                                                              :actual (not (= 3 2)),
-                                                              :file "test_junit.clj",
-                                                              :line 8})])]))))
+  (is (element?
+       (#'junit/suite-xml {:ns (find-ns 'clojure.core)}
+                          [(#'junit/testcase-xml {:type :end-test-var
+                                                  :name #'clojure.core/map
+                                                  :elapsed 0.03}
+                                                 [(#'junit/failure-xml
+                                                   {:expected (= 3 (+ 1 1)),
+                                                    :message nil,
+                                                    :type :fail,
+                                                    :actual (not (= 3 2)),
+                                                    :file "test_junit.clj",
+                                                    :line 8})])]))))
 
 (deftest junit-doesn't-break-return-code
   ;; `lein test` assumes tests return a map.

--- a/test/circleci/test/report/test_junit.clj
+++ b/test/circleci/test/report/test_junit.clj
@@ -1,6 +1,5 @@
 (ns circleci.test.report.test-junit
   (:require [clojure.test :refer (deftest testing is)]
-            [clojure.data.xml.node :refer [element?]]
             circleci.test
             circleci.test.report
             [circleci.test.report.junit :as junit])
@@ -8,13 +7,13 @@
            java.nio.file.attribute.FileAttribute))
 
 (deftest failure-works
-  (is (element? (#'junit/failure-xml
-                 {:expected (= 3 (+ 1 1)),
-                  :message nil,
-                  :type :fail,
-                  :actual (not (= 3 2)),
-                  :file "test_junit.clj",
-                  :line 8}))))
+  (is (#'junit/element? (#'junit/failure-xml
+                         {:expected (= 3 (+ 1 1)),
+                          :message nil,
+                          :type :fail,
+                          :actual (not (= 3 2)),
+                          :file "test_junit.clj",
+                          :line 8}))))
 
 (deftest testcase-works
   (let [ret (#'junit/testcase-xml {:type :end-test-var
@@ -27,12 +26,12 @@
                                     :actual (not (= 3 2)),
                                     :file "test_junit.clj",
                                     :line 8}))]
-    (is (element? ret))
+    (is (#'junit/element? ret))
     (testing "it has a time"
       (is (-> ret :attrs :time float?)))))
 
 (deftest testsuite-works
-  (is (element?
+  (is (#'junit/element?
        (#'junit/suite-xml {:ns (find-ns 'clojure.core)}
                           [(#'junit/testcase-xml {:type :end-test-var
                                                   :name #'clojure.core/map


### PR DESCRIPTION
Necessary changes to support alpha version of clojure.data.xml, which
supports clojurescript and xml namespaces.