### PR TITLE
Include more detail in Junit failure messages

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject circleci/circleci.test "0.4.2"
+(defproject circleci/circleci.test "0.4.2-SNAPSHOT"
   :description "clojure.test compatible test-runner"
   :url "https://github.com/circleci/circleci.test"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Failures now look like
```xml
  <testcase name="post-pipeline" time="0.92274262">
    <failure type="assertion failure" message="FAIL in circle.test-foo/ (my-test-name) (test_foo.clj:115)
can specify parameters
expected: (let [request-body (json/generate-string {:foo &quot;foo&quot;, :bar &quot;v2.0&quot;}) response (api-call user :post sample-uri request-body)] (= 200 (:status response)))
  actual: false">
    </failure>
  </testcase>
```

Also added `-SNAPSHOT` to the project version.