### PR TITLE
Add support for cljc

### DIFF
--- a/src/circleci/test.clj
+++ b/src/circleci/test.clj
@@ -223,7 +223,7 @@
 
 (defn- nses-in-directories [dirs]
   (for [dir dirs f (file-seq (io/file dir))
-        :when (re-find #"\.clj$" (str f))]
+        :when (re-find #"\.cljc?$" (str f))]
     (second (read-string (slurp f)))))
 
 (defn dir


### PR DESCRIPTION
`nses-in-directories` was only looking for `.clj` files. Added support for `.cljc`.