### PR TITLE
Add a CIDER-compatible test reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ in a test selector as a command-line argument:
 
 ### Reporters
 
+#### JUnit
+
 In order to gather metadata about your test runs, you can configure
 `circleci.test` to emit output
 in [JUnit XML format](https://ant.apache.org/manual/Tasks/junitreport.html) by
@@ -74,6 +76,20 @@ re-run only the set of tests which previously failed. Adding an alias in
 ```clj
 :aliases {"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
           "retest" ["run" "-m" "circleci.test.retest"]}
+```
+
+#### CIDER
+
+`circleci.test` by default breaks [CIDER](https://cider.mx) test
+reports. To avoid this, use these settings in your
+`dev-resources/circleci_test/config.clj` to activate the CIDER test
+result adapter:
+
+```clojure
+(require '[circleci.test.report.cider :as cider])
+
+{:reporters [circleci.test.report/clojure-test-reporter
+             cider/reporter]}
 ```
 
 ### Running tests from a repl

--- a/src/circleci/test/report/cider.clj
+++ b/src/circleci/test/report/cider.clj
@@ -1,0 +1,36 @@
+(ns circleci.test.report.cider
+  "CIDER-compatible test reporter."
+  (:require [circleci.test.report :refer [TestReporter]]
+            [cider.nrepl.middleware.test :as cider]))
+
+(deftype CIDERTestReporter []
+  TestReporter
+  (default [this m]
+    (cider/report m))
+
+  (pass [this m]
+    (cider/report m))
+
+  (fail [this m]
+    (cider/report m))
+
+  (error [this m]
+    (cider/report m))
+
+  (summary [this m]
+    (cider/report m))
+
+  (begin-test-ns [this m]
+    (cider/report m))
+
+  (end-test-ns [this m]
+    (cider/report m))
+
+  (begin-test-var [this m]
+    (cider/report m))
+
+  (end-test-var [this m]
+    (cider/report m)))
+
+(defn reporter [_config]
+  (->CIDERTestReporter))


### PR DESCRIPTION
I didn't pull in the Cider middleware as a dependency, but I think this should work if it's present and just ignore it if not evaluated?

Anecdotally this works for me™.